### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
       - .github/workflows/build.yml
       - src/*
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -107,6 +110,8 @@ jobs:
           path: git-credential-github-keychain.macos.zip
 
   create_release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: [build_arm, build_armv7, build_macos, build_x86_64]
     if: startsWith(github.event.ref, 'refs/tags/v')


### PR DESCRIPTION
Potential fix for [https://github.com/jakewilkins/git-credential-github-keychain/security/code-scanning/12](https://github.com/jakewilkins/git-credential-github-keychain/security/code-scanning/12)

Add explicit `permissions` to enforce least privilege:

- At workflow root (applies to all jobs): set `contents: read` so build jobs can checkout code and read repository content.
- For `create_release` job: override with `contents: write` because it creates releases and uploads assets.

This preserves current functionality while removing reliance on mutable repository/org defaults.

Edit file: `.github/workflows/build.yml`
- Insert a root-level `permissions:` block between `on:` and `env:` (or any top-level location before `jobs:`).
- Insert a job-level `permissions:` block under `create_release:`.

No imports/dependencies/methods are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
